### PR TITLE
url2file.c: fix copyright year

### DIFF
--- a/docs/examples/url2file.c
+++ b/docs/examples/url2file.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms


### PR DESCRIPTION
Follow-up to 525787269599b5