### PR TITLE
examples/postinmemory.c: Call curl_global_cleanup always

### DIFF
--- a/docs/examples/postinmemory.c
+++ b/docs/examples/postinmemory.c
@@ -104,10 +104,9 @@ int main(void)
 
     /* always cleanup */
     curl_easy_cleanup(curl);
-
-    /* we're done with libcurl, so clean it up */
-    curl_global_cleanup();
   }
+
   free(chunk.memory);
+  curl_global_cleanup();
   return 0;
 }


### PR DESCRIPTION
Prior to this change curl_global_cleanup was not called if
curl_easy_init failed.

Reported-by: kouzhudong@users.noreply.github.com

Fixes https://github.com/curl/curl/issues/4751