### PR TITLE
tool_operate: fix mem leak when failed config parse

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -720,8 +720,10 @@ static CURLcode single_transfer(struct GlobalConfig *global,
       if(SetHTTPrequest(config, HTTPREQ_SIMPLEPOST, &config->httpreq))
         result = CURLE_FAILED_INIT;
     }
-    if(result)
+    if(result) {
+      single_transfer_cleanup(config);
       return result;
+    }
   }
   if(!state->urlnode) {
     /* first time caller, setup things */


### PR DESCRIPTION
Found by fuzzing the config file.

Reported-by: Geeknik Labs

Fixes https://github.com/curl/curl/issues/4767