### PR TITLE
tests: Fix bounce requests with truncated writes

### DIFF
--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -1242,6 +1242,8 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
     logmsg("Sending response failed. Only (%zu bytes) of (%zu bytes) "
            "were sent",
            responsesize-count, responsesize);
+    prevtestno = req->testno;
+    prevpartno = req->partno;
     free(ptr);
     free(cmd);
     return -1;


### PR DESCRIPTION
Prior to this change the swsbounce check in service_connection could
fail because prevtestno and prevpartno were not set, which would cause
the wrong response data to be sent to some tests and cause them to fail.

Ref: https://github.com/curl/curl/pull/4717#issuecomment-570240785