### PR TITLE
curl:getparameter return error for --http3 if libcurl doesn't support

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -1209,7 +1209,10 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         break;
       case '4': /* --http3 */
         /* HTTP version 3 go over QUIC - at once */
-        config->httpversion = CURL_HTTP_VERSION_3;
+        if(curlinfo->features & CURL_VERSION_HTTP3)
+          config->httpversion = CURL_HTTP_VERSION_3;
+        else
+          return PARAM_LIBCURL_DOESNT_SUPPORT;
         break;
       case '9':
         /* Allow HTTP/0.9 responses! */


### PR DESCRIPTION
Closes #4785