### PR TITLE
azure: disable brotli on the macos debug-builds

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -110,7 +110,7 @@ jobs:
     - script: brew update && brew install libtool autoconf automake nghttp2 pkg-config
       displayName: Install packages
 
-    - script: ./buildconf && ./configure --enable-debug --enable-werror
+    - script: ./buildconf && ./configure --enable-debug --enable-werror --without-brotli
       displayName: 'Run configure'
 
     - script: make


### PR DESCRIPTION
Because of:

brotli/decode.h:204:33: error: variable length array used [-Werror,-Wvla]
    const uint8_t encoded_buffer[BROTLI_ARRAY_PARAM(encoded_size)],

Closes #4925