### PR TITLE
CURLINFO_COOKIELIST.3: Fix example

### DIFF
--- a/docs/libcurl/opts/CURLINFO_COOKIELIST.3
+++ b/docs/libcurl/opts/CURLINFO_COOKIELIST.3
@@ -45,8 +45,8 @@ CURL *curl = curl_easy_init();
 if(curl) {
   curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
 
-  /* enable the cookie engine with a non-existing file */
-  curl_easy_setopt(curl, CURLOPT_COOKIEFILE, "-");
+  /* enable the cookie engine */
+  curl_easy_setopt(curl, CURLOPT_COOKIEFILE, "");
 
   res = curl_easy_perform(curl);
 
@@ -58,7 +58,7 @@ if(curl) {
       /* a linked list of cookies in cookie file format */
       struct curl_slist *each = cookies;
       while(each) {
-        printf("%s", each->data);
+        printf("%s\\n", each->data);
         each = each->next;
       }
       /* we must free these cookies when we're done */


### PR DESCRIPTION
Prior to this change the example would try to import cookies from stdin,
which wasn't what was intended.

Reported-by: 3dyd@users.noreply.github.com

Fixes https://github.com/curl/curl/issues/4930