### PR TITLE
win32: USE_WIN32_CRYPTO to enable Win32 based MD4, MD5 and SHA256 fun…

### DIFF
--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -714,7 +714,9 @@ Vista
 #endif
 
 /* Define to use the Windows crypto library. */
+#if !defined(CURL_WINDOWS_APP)
 #define USE_WIN32_CRYPTO
+#endif
 
 /* Define to use Unix sockets. */
 #if defined(_MSC_VER) && (_MSC_VER >= 1500)

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -124,7 +124,7 @@ static void MD5_Final(unsigned char digest[16], MD5_CTX *ctx)
   CC_MD5_Final(digest, ctx);
 }
 
-#elif defined(WIN32) && !defined(CURL_WINDOWS_APP)
+#elif defined(USE_WIN32_CRYPTO)
 
 #include <wincrypt.h>
 #include "curl_memory.h"

--- a/src/tool_metalink.c
+++ b/src/tool_metalink.c
@@ -73,7 +73,7 @@
    and later. If you're building for an older cat, well, sorry. */
 #  define COMMON_DIGEST_FOR_OPENSSL
 #  include <CommonCrypto/CommonDigest.h>
-#elif defined(WIN32)
+#elif defined(USE_WIN32_CRYPTO)
 /* For Windows: If no other crypto library is provided, we fallback
    to the hash functions provided within the Microsoft Windows CryptoAPI */
 #  include <wincrypt.h>
@@ -381,7 +381,7 @@ static void SHA256_Final(unsigned char digest[32], SHA256_CTX *ctx)
   sha256_finish(ctx, digest);
 }
 
-#elif defined(WIN32)
+#elif defined(USE_WIN32_CRYPTO)
 
 static void win32_crypto_final(struct win32_crypto_hash *ctx,
                                unsigned char *digest,


### PR DESCRIPTION
…ctions

Whilst lib\md4.c used this pre-processor, lib\md5.c and
src\tool_metalink.c did not and simply relied on the WIN32
pre-processor directive.

Reviewed-by: Marcel Raad
Closes #4955