### PR TITLE
sftp: fix segfault regression introduced by #4747

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -171,7 +171,7 @@ test1424 test1425 test1426 test1427 \
 test1428 test1429 test1430 test1431 test1432 test1433 test1434 test1435 \
 test1436 test1437 test1438 test1439 test1440 test1441 test1442 test1443 \
 test1444 test1445 test1446 test1447 test1448 test1449 test1450 test1451 \
-test1452 test1453 test1454 test1455 test1456 test1457 test1458\
+test1452 test1453 test1454 test1455 test1456 test1457 test1458 test1459 \
 test1500 test1501 test1502 test1503 test1504 test1505 test1506 test1507 \
 test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \
 test1516 test1517 test1518 test1519 test1520 test1521 test1522 test1523 \

--- a/tests/data/test1459
+++ b/tests/data/test1459
@@ -1,0 +1,46 @@
+<testcase>
+<info>
+<keywords>
+SFTP
+known_hosts
+</keywords>
+</info>
+
+#
+# Client-side
+<client>
+<server>
+sftp
+</server>
+<precheck>
+mkdir -p %PWD/log/test1459.dir/.ssh
+</precheck>
+<features>
+sftp
+</features>
+ <name>
+SFTP with corrupted known_hosts
+ </name>
+ <command>
+-u : sftp://%HOSTIP:%SSHPORT/ -l
+</command>
+<file name="log/test1459.dir/.ssh/known_hosts">
+|1|qy29Y1x/+/F39AzdG5515YSSw+c=|iB2WX5jrU3ZTWc+ZfGau7HHEvBc= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAIEAynDN8cDJ3xNzRjTNNGciSHSxpubxhZ6YnkLdp1TkrGW8n\
+R93Ey5VtBeBblYTRlFXBWJgKFcTKBRJ/O4qBZwbUgt10AHj31i6h8NehfT19tR8wG/YCmj3KtYLHmwdzmW1edEL9G2NdX2KiKYv7/zuly3QvmP0QA0NhWkAz0KdWNM=
+</file>
+<setenv>
+CURL_HOME=%PWD/log/test1459.dir
+</setenv>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+60
+</errorcode>
+<valgrind>
+disable
+</valgrind>
+</verify>
+</testcase>
+


### PR DESCRIPTION
This fix adds a defensive check for the case where the char *name in
struct libssh2_knownhost is NULL

Fixes #5041
Closes #5062