### PR TITLE
windows: enable UnixSockets with all build toolchains

### DIFF
--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -719,12 +719,15 @@ Vista
 #endif
 
 /* Define to use Unix sockets. */
-#if defined(_MSC_VER) && (_MSC_VER >= 1500)
-/* sdkddkver.h first shipped with Platform SDK v6.0A included with VS2008 */
-#include <sdkddkver.h>
-#if defined(NTDDI_WIN10_RS4)
 #define USE_UNIX_SOCKETS
-#endif
+#if !defined(UNIX_PATH_MAX)
+  /* Replicating logic present in afunix.h of newer Windows 10 SDK versions */
+# define UNIX_PATH_MAX 108
+# include <ws2tcpip.h>
+  typedef struct sockaddr_un {
+    ADDRESS_FAMILY sun_family;
+    char sun_path[UNIX_PATH_MAX];
+  } SOCKADDR_UN, *PSOCKADDR_UN;
 #endif
 
 /* ---------------------------------------------------------------- */

--- a/lib/curl_addrinfo.c
+++ b/lib/curl_addrinfo.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -48,10 +48,6 @@
 #if defined(NETWARE) && defined(__NOVELL_LIBC__)
 #  undef  in_addr_t
 #  define in_addr_t unsigned long
-#endif
-
-#if defined(WIN32) && defined(USE_UNIX_SOCKETS)
-#include <afunix.h>
 #endif
 
 #include <stddef.h>


### PR DESCRIPTION
Extend existing unix socket support in Windows builds to be
enabled for all toolchain vendors or versions. (Previously
it was only supported with certain MSVC versions + more recent
Windows 10 SDKs)

Ref: https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/
Ref: https://github.com/curl/curl/issues/5162
Closes: https://github.com/curl/curl/pull/5170